### PR TITLE
Expand Neon Broker 99: Audio, Visuals, Logic & Dark Web

### DIFF
--- a/.github/workflows/deploy-neon-broker.yml
+++ b/.github/workflows/deploy-neon-broker.yml
@@ -1,0 +1,49 @@
+name: Deploy Neon Broker 99
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "neon_broker/**"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: cd neon_broker && npm ci
+
+      - name: Build
+        run: cd neon_broker && npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'neon_broker/dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/neon_broker/src/assets/styles.css
+++ b/neon_broker/src/assets/styles.css
@@ -21,6 +21,68 @@ canvas {
     height: 100%;
 }
 
+/* --- CRT Overlay Effect --- */
+#app::before {
+    content: " ";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: linear-gradient(
+        rgba(18, 16, 16, 0) 50%,
+        rgba(0, 0, 0, 0.25) 50%
+    ), linear-gradient(
+        90deg,
+        rgba(255, 0, 0, 0.06),
+        rgba(0, 255, 0, 0.02),
+        rgba(0, 0, 255, 0.06)
+    );
+    z-index: 20;
+    background-size: 100% 2px, 3px 100%;
+    pointer-events: none;
+}
+
+#app::after {
+    content: " ";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: rgba(18, 16, 16, 0.1);
+    opacity: 0;
+    z-index: 20;
+    pointer-events: none;
+    animation: flicker 0.15s infinite;
+}
+
+@keyframes flicker {
+    0% { opacity: 0.02795; }
+    5% { opacity: 0.04169; }
+    10% { opacity: 0.03813; }
+    15% { opacity: 0.06326; }
+    20% { opacity: 0.01353; }
+    25% { opacity: 0.01254; }
+    30% { opacity: 0.03713; }
+    35% { opacity: 0.05739; }
+    40% { opacity: 0.08984; }
+    45% { opacity: 0.04781; }
+    50% { opacity: 0.05378; }
+    55% { opacity: 0.07663; }
+    60% { opacity: 0.03352; }
+    65% { opacity: 0.06124; }
+    70% { opacity: 0.02347; }
+    75% { opacity: 0.08419; }
+    80% { opacity: 0.03212; }
+    85% { opacity: 0.06569; }
+    90% { opacity: 0.05142; }
+    95% { opacity: 0.03295; }
+    100% { opacity: 0.07172; }
+}
+
 .panic-btn {
     position: absolute;
     bottom: 30px;
@@ -35,6 +97,16 @@ canvas {
     cursor: pointer;
     box-shadow: 0 0 15px #ff0000;
     transition: all 0.1s;
+    z-index: 30; /* Above CRT overlay for interactivity, but overlay covers it visually? No, standard z-index stacking context means it will be covered by ::before if inside #app. */
+}
+
+/* Ensure Panic Button is above scanlines if needed, or below.
+   If we want scanlines over button, button z-index < overlay z-index.
+   But button needs to be clickable. `pointer-events: none` on overlay handles clicks.
+   So let's put button under overlay visually.
+   Overlay z-index = 20. Button z-index = 10.
+*/
+.panic-btn {
     z-index: 10;
 }
 

--- a/neon_broker/src/core/GameManager.ts
+++ b/neon_broker/src/core/GameManager.ts
@@ -1,0 +1,29 @@
+import { MarketEngine } from './MarketEngine';
+import { Player } from './Player';
+
+export class GameManager {
+    engine: MarketEngine;
+    player: Player;
+    currentLevel: number = 1;
+
+    constructor(engine: MarketEngine, player: Player) {
+        this.engine = engine;
+        this.player = player;
+    }
+
+    startNextLevel() {
+        this.currentLevel++;
+        // Keep cash, reset debt with increase
+        const baseDebt = 25000;
+        this.player.debt = baseDebt * Math.pow(1.5, this.currentLevel - 1);
+        this.engine.startLevel(this.currentLevel);
+    }
+
+    restartGame() {
+        this.currentLevel = 1;
+        this.player.cash = 1000;
+        this.player.debt = 25000;
+        this.player.portfolio = [];
+        this.engine.startLevel(1);
+    }
+}

--- a/neon_broker/src/core/MarketEngine.ts
+++ b/neon_broker/src/core/MarketEngine.ts
@@ -1,6 +1,11 @@
+import { SoundManager } from './SoundManager';
+
+export type Sector = 'TECH' | 'ENERGY' | 'HEAVY' | 'FINANCE';
+
 export interface Stock {
     symbol: string;
     name: string;
+    sector: Sector;
     price: number;
     volatility: number;
     history: number[];
@@ -16,6 +21,7 @@ export class MarketEngine {
     timeRemaining: number = 180; // 3 minutes
     isGameOver: boolean = false;
     gameResult: 'WIN' | 'LOSE' | null = null;
+    level: number = 1;
 
     // News events
     news: string[] = [];
@@ -28,17 +34,40 @@ export class MarketEngine {
     readonly FREEZE_DURATION = 5;
     readonly FREEZE_COOLDOWN_DURATION = 15;
 
-    constructor() {
+    soundManager: SoundManager;
+
+    constructor(soundManager: SoundManager) {
+        this.soundManager = soundManager;
+        this.initStocks();
+    }
+
+    startLevel(level: number) {
+        this.level = level;
+        this.timeRemaining = 180 - (level - 1) * 10; // Less time each level
+        if (this.timeRemaining < 60) this.timeRemaining = 60;
+
+        this.isGameOver = false;
+        this.gameResult = null;
+        this.news = [`LEVEL ${level} START`];
+        this.isFrozen = false;
+        this.freezeCooldown = 0;
+
+        // Difficulty scaling
+        this.tickRate = Math.max(0.1, 0.5 - (level * 0.05)); // Faster ticks
+
         this.initStocks();
     }
 
     initStocks() {
+        // More volatility at higher levels
+        const vMod = 1 + (this.level * 0.2);
+
         this.stocks = [
-            { symbol: 'NEON', name: 'Neon Corp', price: 100, volatility: 2, history: [], trend: 0.5 },
-            { symbol: 'CYBR', name: 'Cyber Sys', price: 50, volatility: 5, history: [], trend: -0.2 },
-            { symbol: 'DATA', name: 'Data Link', price: 200, volatility: 1, history: [], trend: 0.1 },
-            { symbol: 'GRID', name: 'Grid Energy', price: 75, volatility: 3, history: [], trend: 0 },
-            { symbol: 'VOID', name: 'Void Ind', price: 10, volatility: 8, history: [], trend: -0.5 }
+            { symbol: 'NEON', name: 'Neon Corp', sector: 'TECH', price: 100, volatility: 2 * vMod, history: [], trend: 0.5 },
+            { symbol: 'CYBR', name: 'Cyber Sys', sector: 'TECH', price: 50, volatility: 5 * vMod, history: [], trend: -0.2 },
+            { symbol: 'DATA', name: 'Data Link', sector: 'TECH', price: 200, volatility: 1 * vMod, history: [], trend: 0.1 },
+            { symbol: 'GRID', name: 'Grid Energy', sector: 'ENERGY', price: 75, volatility: 3 * vMod, history: [], trend: 0 },
+            { symbol: 'VOID', name: 'Void Ind', sector: 'HEAVY', price: 10, volatility: 8 * vMod, history: [], trend: -0.5 }
         ];
 
         // Fill initial history
@@ -56,6 +85,7 @@ export class MarketEngine {
             this.timeRemaining = 0;
             this.isGameOver = true;
             this.gameResult = 'LOSE';
+            this.soundManager.playError();
         }
 
         // Handle Freeze Logic
@@ -91,6 +121,7 @@ export class MarketEngine {
         if (debt <= 0) {
             this.isGameOver = true;
             this.gameResult = 'WIN';
+            this.soundManager.playLevelUp();
         }
     }
 
@@ -108,23 +139,41 @@ export class MarketEngine {
     }
 
     generateNews() {
-        const events = [
+        interface NewsEvent {
+            text: string;
+            impact: number;
+            symbol?: string;
+            sector?: Sector;
+        }
+
+        const events: NewsEvent[] = [
             { text: "Market Crash Imminent!", impact: -5 },
             { text: "Neon Corp announces record profits!", impact: 5, symbol: 'NEON' },
             { text: "Cyber Sys hacked!", impact: -10, symbol: 'CYBR' },
             { text: "New energy source discovered.", impact: 3, symbol: 'GRID' },
-            { text: "Void Ind CEO arrested.", impact: -5, symbol: 'VOID' }
+            { text: "Void Ind CEO arrested.", impact: -5, symbol: 'VOID' },
+            { text: "Tech Bubble bursts!", impact: -8, sector: 'TECH' },
+            { text: "Energy crisis looming.", impact: 4, sector: 'ENERGY' }, // Prices go up in crisis? or down? Usually energy prices go up.
+            { text: "Heavy Industry subsidies approved.", impact: 6, sector: 'HEAVY' }
         ];
+
         const event = events[Math.floor(Math.random() * events.length)];
         this.news.unshift(event.text);
         if (this.news.length > 5) this.news.pop();
+
+        this.soundManager.playNewsAlert();
 
         if (event.symbol) {
             const s = this.stocks.find(st => st.symbol === event.symbol);
             if (s) {
                 s.price += event.impact;
-                s.price = Math.max(0.1, s.price); // Prevent negative price
+                s.price = Math.max(0.1, s.price);
             }
+        } else if (event.sector) {
+            this.stocks.filter(st => st.sector === event.sector).forEach(s => {
+                s.price += event.impact;
+                s.price = Math.max(0.1, s.price);
+            });
         } else {
             // Global impact
              this.stocks.forEach(s => {
@@ -138,6 +187,10 @@ export class MarketEngine {
         if (!this.isFrozen && this.freezeCooldown <= 0) {
             this.isFrozen = true;
             this.freezeTimer = this.FREEZE_DURATION;
+            this.soundManager.playPanic();
+        } else {
+            // Play error if cooldown
+            if(this.freezeCooldown > 0) this.soundManager.playError();
         }
     }
 }

--- a/neon_broker/src/core/Player.ts
+++ b/neon_broker/src/core/Player.ts
@@ -14,36 +14,75 @@ export class Player {
         this.debt = startDebt;
     }
 
+    // Buying: Opens Long or Covers Short
     buy(symbol: string, price: number, quantity: number): boolean {
         const cost = price * quantity;
-        if (this.cash >= cost) {
+
+        // Margin Trading: Allow cash to go down to -5000 (Credit Limit)
+        const creditLimit = 5000;
+
+        if (this.cash + creditLimit >= cost) {
             this.cash -= cost;
-            const item = this.portfolio.find(p => p.symbol === symbol);
-            if (item) {
-                // Update average price
+
+            let item = this.portfolio.find(p => p.symbol === symbol);
+            if (!item) {
+                item = { symbol, quantity: 0, avgPrice: 0 };
+                this.portfolio.push(item);
+            }
+
+            if (item.quantity >= 0) {
+                // Adding to Long position
                 const totalVal = item.avgPrice * item.quantity + cost;
                 item.quantity += quantity;
                 item.avgPrice = totalVal / item.quantity;
             } else {
-                this.portfolio.push({ symbol, quantity, avgPrice: price });
+                // Covering Short position
+                // When covering, we don't change avgPrice of the remaining short,
+                // but effectively we are "realizing" the loss/gain on the portion covered.
+                // Simplified: just reduce magnitude of negative quantity
+                item.quantity += quantity;
+                if (item.quantity === 0) {
+                    this.portfolio = this.portfolio.filter(p => p.symbol !== symbol);
+                }
             }
             return true;
         }
         return false;
     }
 
+    // Selling: Closes Long or Opens Short
     sell(symbol: string, price: number, quantity: number): boolean {
-        const item = this.portfolio.find(p => p.symbol === symbol);
-        if (item && item.quantity >= quantity) {
-            const revenue = price * quantity;
-            this.cash += revenue;
-            item.quantity -= quantity;
-            if (item.quantity === 0) {
-                this.portfolio = this.portfolio.filter(p => p.symbol !== symbol);
-            }
-            return true;
+        let item = this.portfolio.find(p => p.symbol === symbol);
+
+        // Limit Short Selling Position to prevent infinite risk
+        const currentQty = item ? item.quantity : 0;
+        if (currentQty - quantity < -100) return false; // Max short 100 shares
+
+        const revenue = price * quantity;
+        this.cash += revenue;
+
+        if (!item) {
+            item = { symbol, quantity: 0, avgPrice: price }; // Initial short price
+            this.portfolio.push(item);
         }
-        return false;
+
+        if (item.quantity > 0) {
+            // Selling Long
+            item.quantity -= quantity;
+        } else {
+            // Shorting
+            // When shorting more, avgPrice is the weighted average of entry prices
+            const shortQty = Math.abs(item.quantity);
+            const totalShortVal = item.avgPrice * shortQty + revenue;
+            item.quantity -= quantity;
+            item.avgPrice = totalShortVal / Math.abs(item.quantity);
+        }
+
+        if (item.quantity === 0) {
+             this.portfolio = this.portfolio.filter(p => p.symbol !== symbol);
+        }
+
+        return true;
     }
 
     payDebt(amount: number): boolean {
@@ -54,5 +93,14 @@ export class Player {
             return true;
         }
         return false;
+    }
+
+    getNetWorth(currentPrices: Record<string, number>): number {
+        let equity = 0;
+        this.portfolio.forEach(p => {
+             const price = currentPrices[p.symbol] || 0;
+             equity += p.quantity * price;
+        });
+        return this.cash + equity - this.debt;
     }
 }

--- a/neon_broker/src/core/SoundManager.ts
+++ b/neon_broker/src/core/SoundManager.ts
@@ -1,0 +1,245 @@
+export class SoundManager {
+    ctx: AudioContext;
+    masterGain: GainNode;
+    isMuted: boolean = false;
+
+    // Music state
+    nextNoteTime: number = 0;
+    noteIndex: number = 0;
+    isPlayingMusic: boolean = false;
+    tempo: number = 120;
+    lookahead: number = 25.0; // ms
+    scheduleAheadTime: number = 0.1; // s
+
+    constructor() {
+        this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+        this.masterGain = this.ctx.createGain();
+        this.masterGain.gain.value = 0.3; // Default volume
+        this.masterGain.connect(this.ctx.destination);
+    }
+
+    resume() {
+        if (this.ctx.state === 'suspended') {
+            this.ctx.resume();
+        }
+    }
+
+    toggleMute() {
+        this.isMuted = !this.isMuted;
+        this.masterGain.gain.value = this.isMuted ? 0 : 0.3;
+    }
+
+    // --- SFX Generators ---
+
+    playTone(freq: number, type: OscillatorType, duration: number, startTime: number = 0) {
+        if (this.isMuted) return;
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+
+        osc.type = type;
+        osc.frequency.setValueAtTime(freq, this.ctx.currentTime + startTime);
+
+        gain.gain.setValueAtTime(0.1, this.ctx.currentTime + startTime);
+        gain.gain.exponentialRampToValueAtTime(0.01, this.ctx.currentTime + startTime + duration);
+
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.start(this.ctx.currentTime + startTime);
+        osc.stop(this.ctx.currentTime + startTime + duration);
+    }
+
+    playBuy() {
+        // Ascending chime
+        this.playTone(440, 'square', 0.1, 0);
+        this.playTone(880, 'square', 0.2, 0.1);
+    }
+
+    playSell() {
+        // Descending coin sound
+        this.playTone(880, 'sine', 0.1, 0);
+        this.playTone(440, 'sine', 0.2, 0.1);
+    }
+
+    playError() {
+        // Low buzz
+        this.playTone(150, 'sawtooth', 0.3, 0);
+    }
+
+    playPanic() {
+        // Siren effect
+        if (this.isMuted) return;
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(600, this.ctx.currentTime);
+        osc.frequency.linearRampToValueAtTime(300, this.ctx.currentTime + 0.5);
+        osc.frequency.linearRampToValueAtTime(600, this.ctx.currentTime + 1.0);
+
+        gain.gain.value = 0.1;
+        gain.gain.linearRampToValueAtTime(0, this.ctx.currentTime + 1.0);
+
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+
+        osc.start();
+        osc.stop(this.ctx.currentTime + 1.0);
+    }
+
+    playNewsAlert() {
+        // Teletype / Data burst
+        for(let i=0; i<5; i++) {
+            this.playTone(1000 + (Math.random() * 500), 'square', 0.05, i * 0.08);
+        }
+    }
+
+    playLevelUp() {
+        // Victory fanfare
+        const now = 0;
+        this.playTone(523.25, 'square', 0.2, now);
+        this.playTone(659.25, 'square', 0.2, now + 0.2);
+        this.playTone(783.99, 'square', 0.4, now + 0.4);
+        this.playTone(1046.50, 'square', 0.6, now + 0.6);
+    }
+
+    // --- Music Sequencer ---
+
+    startMusic() {
+        if (this.isPlayingMusic) return;
+        this.isPlayingMusic = true;
+        this.nextNoteTime = this.ctx.currentTime;
+        this.scheduler();
+    }
+
+    stopMusic() {
+        this.isPlayingMusic = false;
+    }
+
+    scheduler() {
+        if (!this.isPlayingMusic) return;
+
+        while (this.nextNoteTime < this.ctx.currentTime + this.scheduleAheadTime) {
+            this.scheduleNote(this.noteIndex, this.nextNoteTime);
+            this.nextNote();
+        }
+
+        setTimeout(() => this.scheduler(), this.lookahead);
+    }
+
+    nextNote() {
+        const secondsPerBeat = 60.0 / this.tempo;
+        this.nextNoteTime += 0.25 * secondsPerBeat; // 16th notes
+        this.noteIndex++;
+        if (this.noteIndex === 16) this.noteIndex = 0;
+    }
+
+    scheduleNote(beatNumber: number, time: number) {
+        if (this.isMuted) return;
+
+        // Simple Bassline (Cyberpunk/Darkwave style)
+        // Root notes: C (low) -> G -> F -> G
+
+        // Bass Kick on 0, 4, 8, 12
+        if (beatNumber % 4 === 0) {
+            this.playKick(time);
+        }
+
+        // Hi-hat on every off-beat 16th
+        if (beatNumber % 2 !== 0) {
+            this.playHiHat(time);
+        }
+
+        // Snare on 4 and 12
+        if (beatNumber === 4 || beatNumber === 12) {
+             this.playSnare(time);
+        }
+
+        // Bass Synth
+        if (beatNumber === 0 || beatNumber === 3 || beatNumber === 8 || beatNumber === 11) {
+            const osc = this.ctx.createOscillator();
+            const gain = this.ctx.createGain();
+
+            // Progression: C2, G1, F1, G1
+            // C2 = 65.41
+            // G1 = 49.00
+            // F1 = 43.65
+            const cycle = Math.floor(Date.now() / 4000) % 4; // Change root occasionally
+            const notes = [65.41, 49.00, 43.65, 49.00];
+
+            osc.frequency.value = notes[cycle];
+            osc.type = 'sawtooth';
+
+            // Filter for that "acid" / synth bass feel
+            const filter = this.ctx.createBiquadFilter();
+            filter.type = 'lowpass';
+            filter.frequency.value = 400;
+
+            gain.gain.setValueAtTime(0.1, time);
+            gain.gain.exponentialRampToValueAtTime(0.001, time + 0.2);
+
+            osc.connect(filter);
+            filter.connect(gain);
+            gain.connect(this.masterGain);
+
+            osc.start(time);
+            osc.stop(time + 0.2);
+        }
+    }
+
+    playKick(time: number) {
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+        osc.frequency.setValueAtTime(150, time);
+        osc.frequency.exponentialRampToValueAtTime(0.01, time + 0.5);
+        gain.gain.setValueAtTime(0.4, time); // Louder kick
+        gain.gain.exponentialRampToValueAtTime(0.01, time + 0.5);
+
+        osc.connect(gain);
+        gain.connect(this.masterGain);
+        osc.start(time);
+        osc.stop(time + 0.5);
+    }
+
+    playSnare(time: number) {
+        // Noise buffer for snare
+        const bufferSize = this.ctx.sampleRate * 0.1; // 0.1s
+        const buffer = this.ctx.createBuffer(1, bufferSize, this.ctx.sampleRate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < bufferSize; i++) {
+            data[i] = Math.random() * 2 - 1;
+        }
+
+        const noise = this.ctx.createBufferSource();
+        noise.buffer = buffer;
+        const gain = this.ctx.createGain();
+        gain.gain.setValueAtTime(0.2, time);
+        gain.gain.exponentialRampToValueAtTime(0.01, time + 0.1);
+
+        noise.connect(gain);
+        gain.connect(this.masterGain);
+        noise.start(time);
+    }
+
+    playHiHat(time: number) {
+        // High frequency noise or metal tone
+        // Simplified: high square wave short decay
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.value = 8000;
+        // Highpass filter
+        const filter = this.ctx.createBiquadFilter();
+        filter.type = 'highpass';
+        filter.frequency.value = 7000;
+
+        gain.gain.setValueAtTime(0.05, time);
+        gain.gain.exponentialRampToValueAtTime(0.001, time + 0.05);
+
+        osc.connect(filter);
+        filter.connect(gain);
+        gain.connect(this.masterGain);
+        osc.start(time);
+        osc.stop(time + 0.05);
+    }
+}

--- a/neon_broker/src/main.ts
+++ b/neon_broker/src/main.ts
@@ -4,6 +4,8 @@ import { MarketEngine } from './core/MarketEngine';
 import { Player } from './core/Player';
 import { Terminal } from './ui/Terminal';
 import { PanicButton } from './ui/PanicButton';
+import { SoundManager } from './core/SoundManager';
+import { GameManager } from './core/GameManager';
 
 const app = document.querySelector<HTMLDivElement>('#app')!;
 const canvas = document.createElement('canvas');
@@ -17,9 +19,25 @@ function resize() {
     canvas.height = window.innerHeight;
 }
 
+// Audio System
+const soundManager = new SoundManager();
+
+// Resume AudioContext on interaction
+const resumeAudio = () => {
+    soundManager.resume();
+    soundManager.startMusic();
+    // Remove listeners once resumed
+    window.removeEventListener('click', resumeAudio);
+    window.removeEventListener('keydown', resumeAudio);
+};
+
+window.addEventListener('click', resumeAudio);
+window.addEventListener('keydown', resumeAudio);
+
 const player = new Player(1000, 25000); // Start with $1000 cash, $25k debt
-const engine = new MarketEngine();
-const terminal = new Terminal(engine, player, ctx, canvas.width, canvas.height);
+const engine = new MarketEngine(soundManager);
+const gameManager = new GameManager(engine, player);
+const terminal = new Terminal(engine, player, soundManager, gameManager, ctx, canvas.width, canvas.height);
 const panicBtn = new PanicButton(engine);
 
 window.addEventListener('resize', () => {
@@ -32,6 +50,7 @@ const loop = new GameLoop(
     (dt) => {
         engine.update(dt);
         panicBtn.update();
+        terminal.update(dt);
     },
     () => {
         terminal.draw();

--- a/neon_broker/src/ui/DarkWeb.ts
+++ b/neon_broker/src/ui/DarkWeb.ts
@@ -1,0 +1,123 @@
+import { MarketEngine } from '../core/MarketEngine';
+import { Player } from '../core/Player';
+import { SoundManager } from '../core/SoundManager';
+
+export class DarkWeb {
+    engine: MarketEngine;
+    player: Player;
+    soundManager: SoundManager;
+
+    isVisible: boolean = false;
+    selectedOption: number = 0;
+
+    options = [
+        { name: "BUY INSIDER TIP ($500)", cost: 500, action: 'TIP' },
+        { name: "SABOTAGE RIVAL ($2000)", cost: 2000, action: 'SABOTAGE' },
+        { name: "PUMP STOCK ($3000)", cost: 3000, action: 'PUMP' }
+    ];
+
+    lastResult: string = "";
+
+    constructor(engine: MarketEngine, player: Player, soundManager: SoundManager) {
+        this.engine = engine;
+        this.player = player;
+        this.soundManager = soundManager;
+    }
+
+    toggle() {
+        this.isVisible = !this.isVisible;
+        this.soundManager.playTone(200, 'sawtooth', 0.2);
+    }
+
+    handleInput(key: string) {
+        if (!this.isVisible) return;
+
+        if (key === 'ArrowUp') {
+            this.selectedOption = (this.selectedOption - 1 + this.options.length) % this.options.length;
+            this.soundManager.playTone(300, 'square', 0.05);
+        }
+        if (key === 'ArrowDown') {
+            this.selectedOption = (this.selectedOption + 1) % this.options.length;
+            this.soundManager.playTone(300, 'square', 0.05);
+        }
+        if (key === 'Enter') {
+            this.execute();
+        }
+        if (key === 'Escape') {
+            this.isVisible = false;
+        }
+    }
+
+    execute() {
+        const opt = this.options[this.selectedOption];
+        if (this.player.cash >= opt.cost) {
+            this.player.cash -= opt.cost;
+            this.soundManager.playBuy();
+
+            if (opt.action === 'TIP') {
+                // Reveal a trend
+                const stock = this.engine.stocks[Math.floor(Math.random() * this.engine.stocks.length)];
+                const direction = stock.trend > 0 ? "RISING" : "FALLING";
+                this.lastResult = `TIP: ${stock.symbol} is ${direction} (Vol: ${stock.volatility})`;
+            } else if (opt.action === 'SABOTAGE') {
+                // Crash a random stock
+                const stock = this.engine.stocks[Math.floor(Math.random() * this.engine.stocks.length)];
+                stock.price *= 0.8;
+                stock.trend = -0.5;
+                this.lastResult = `HACK: ${stock.symbol} CRASHED BY 20%`;
+            } else if (opt.action === 'PUMP') {
+                // Pump a random stock
+                const stock = this.engine.stocks[Math.floor(Math.random() * this.engine.stocks.length)];
+                stock.price *= 1.2;
+                stock.trend = 0.5;
+                this.lastResult = `PUMP: ${stock.symbol} BOOSTED BY 20%`;
+            }
+        } else {
+            this.lastResult = "INSUFFICIENT FUNDS FOR HACK";
+            this.soundManager.playError();
+        }
+    }
+
+    draw(ctx: CanvasRenderingContext2D, width: number, height: number) {
+        if (!this.isVisible) return;
+
+        // Overlay
+        ctx.fillStyle = "rgba(0, 0, 0, 0.9)";
+        ctx.fillRect(0, 0, width, height);
+
+        // Border
+        ctx.strokeStyle = "#ff0000";
+        ctx.lineWidth = 4;
+        ctx.strokeRect(50, 50, width - 100, height - 100);
+
+        // Header
+        ctx.fillStyle = "#ff0000";
+        ctx.font = '30px "VT323", monospace';
+        ctx.textAlign = 'center';
+        ctx.fillText("/// DARK WEB ACCESS ///", width/2, 100);
+
+        // Options
+        ctx.textAlign = 'left';
+        this.options.forEach((opt, i) => {
+            if (i === this.selectedOption) {
+                ctx.fillStyle = "#ffffff";
+                ctx.fillText(`> ${opt.name}`, 100, 200 + i * 40);
+            } else {
+                ctx.fillStyle = "#aa0000";
+                ctx.fillText(`  ${opt.name}`, 100, 200 + i * 40);
+            }
+        });
+
+        // Result
+        if (this.lastResult) {
+            ctx.fillStyle = "#ffff00";
+            ctx.textAlign = 'center';
+            ctx.fillText(this.lastResult, width/2, height - 150);
+        }
+
+        ctx.fillStyle = "#ff0000";
+        ctx.font = '20px "VT323", monospace';
+        ctx.fillText("[UP/DOWN] Select   [ENTER] Execute   [ESC] Exit", width/2, height - 80);
+        ctx.textAlign = 'left';
+    }
+}

--- a/neon_broker/src/ui/ParticleSystem.ts
+++ b/neon_broker/src/ui/ParticleSystem.ts
@@ -1,0 +1,52 @@
+export class Particle {
+    x: number;
+    y: number;
+    text: string;
+    color: string;
+    life: number = 1.0; // Seconds
+    vy: number = -20; // Velocity Y
+
+    constructor(x: number, y: number, text: string, color: string) {
+        this.x = x;
+        this.y = y;
+        this.text = text;
+        this.color = color;
+    }
+
+    update(dt: number) {
+        this.y += this.vy * dt;
+        this.life -= dt;
+    }
+}
+
+export class ParticleSystem {
+    particles: Particle[] = [];
+    ctx: CanvasRenderingContext2D;
+
+    constructor(ctx: CanvasRenderingContext2D) {
+        this.ctx = ctx;
+    }
+
+    spawn(x: number, y: number, text: string, color: string) {
+        this.particles.push(new Particle(x, y, text, color));
+    }
+
+    update(dt: number) {
+        this.particles.forEach(p => p.update(dt));
+        this.particles = this.particles.filter(p => p.life > 0);
+    }
+
+    draw() {
+        this.ctx.font = '20px "VT323", monospace';
+        this.ctx.textAlign = 'center';
+
+        this.particles.forEach(p => {
+            this.ctx.globalAlpha = Math.max(0, p.life);
+            this.ctx.fillStyle = p.color;
+            this.ctx.fillText(p.text, p.x, p.y);
+        });
+
+        this.ctx.globalAlpha = 1.0;
+        this.ctx.textAlign = 'left';
+    }
+}

--- a/neon_broker/src/ui/Terminal.ts
+++ b/neon_broker/src/ui/Terminal.ts
@@ -1,34 +1,85 @@
 import { MarketEngine, Stock } from '../core/MarketEngine';
 import { Player } from '../core/Player';
+import { SoundManager } from '../core/SoundManager';
+import { GameManager } from '../core/GameManager';
+import { ParticleSystem } from './ParticleSystem';
+import { DarkWeb } from './DarkWeb';
 
 export class Terminal {
     engine: MarketEngine;
     player: Player;
+    soundManager: SoundManager;
+    gameManager: GameManager;
+    particleSystem: ParticleSystem;
+    darkWeb: DarkWeb;
     ctx: CanvasRenderingContext2D;
     width: number;
     height: number;
 
     selectedStockIndex: number = 0;
+    showHelp: boolean = false;
+
+    // News Ticker
+    tickerOffset: number = 0;
 
     // Message log
     messages: string[] = [];
 
-    constructor(engine: MarketEngine, player: Player, ctx: CanvasRenderingContext2D, width: number, height: number) {
+    constructor(engine: MarketEngine, player: Player, soundManager: SoundManager, gameManager: GameManager, ctx: CanvasRenderingContext2D, width: number, height: number) {
         this.engine = engine;
         this.player = player;
+        this.soundManager = soundManager;
+        this.gameManager = gameManager;
         this.ctx = ctx;
         this.width = width;
         this.height = height;
+        this.particleSystem = new ParticleSystem(ctx);
+        this.darkWeb = new DarkWeb(engine, player, soundManager);
 
         // Handle input
         window.addEventListener('keydown', (e) => {
-            if (this.engine.isGameOver) return; // Disable input on game over
+            if (this.engine.isGameOver) {
+                if (e.key === 'Enter') {
+                    if (this.engine.gameResult === 'WIN') {
+                        this.gameManager.startNextLevel();
+                    } else {
+                        this.gameManager.restartGame();
+                    }
+                }
+                return;
+            }
+
+            // Help Toggle
+            if (e.key.toLowerCase() === 'h') {
+                this.showHelp = !this.showHelp;
+                return;
+            }
+
+            if (this.showHelp) return; // Block input when help is shown
+
+            // Delegate to Dark Web if visible
+            if (this.darkWeb.isVisible) {
+                this.darkWeb.handleInput(e.key);
+                if (e.key === 'Tab') {
+                    e.preventDefault();
+                    this.darkWeb.toggle();
+                }
+                return;
+            }
+
+            if (e.key === 'Tab') {
+                e.preventDefault();
+                this.darkWeb.toggle();
+                return;
+            }
 
             if (e.key === 'ArrowUp') {
                 this.selectedStockIndex = (this.selectedStockIndex - 1 + this.engine.stocks.length) % this.engine.stocks.length;
+                this.soundManager.playTone(800, 'sine', 0.05); // Menu blip
             }
             if (e.key === 'ArrowDown') {
                 this.selectedStockIndex = (this.selectedStockIndex + 1) % this.engine.stocks.length;
+                this.soundManager.playTone(800, 'sine', 0.05); // Menu blip
             }
             if (e.key.toLowerCase() === 'b') {
                 this.handleBuy();
@@ -42,31 +93,47 @@ export class Terminal {
         });
     }
 
+    update(dt: number) {
+        this.particleSystem.update(dt);
+        this.tickerOffset -= 50 * dt; // Scroll speed
+    }
+
     handleBuy() {
         if (this.engine.isFrozen) {
             this.log("CANNOT TRADE WHILE FROZEN");
+            this.soundManager.playError();
             return;
         }
         const stock = this.engine.stocks[this.selectedStockIndex];
         const quantity = 10;
         if (this.player.buy(stock.symbol, stock.price, quantity)) {
+            const cost = stock.price * quantity;
             this.log(`BOUGHT ${quantity} ${stock.symbol} @ $${stock.price.toFixed(2)}`);
+            this.soundManager.playBuy();
+            // Spawn particles at random location near center or consistent location
+            this.particleSystem.spawn(this.width/2, this.height/2, `-${cost.toFixed(0)}`, '#ff0000');
         } else {
             this.log("INSUFFICIENT FUNDS");
+            this.soundManager.playError();
         }
     }
 
     handleSell() {
         if (this.engine.isFrozen) {
             this.log("CANNOT TRADE WHILE FROZEN");
+            this.soundManager.playError();
             return;
         }
         const stock = this.engine.stocks[this.selectedStockIndex];
         const quantity = 10;
         if (this.player.sell(stock.symbol, stock.price, quantity)) {
+             const revenue = stock.price * quantity;
              this.log(`SOLD ${quantity} ${stock.symbol} @ $${stock.price.toFixed(2)}`);
+             this.soundManager.playSell();
+             this.particleSystem.spawn(this.width/2, this.height/2, `+${revenue.toFixed(0)}`, '#00ff00');
         } else {
-             this.log("INSUFFICIENT SHARES");
+             this.log("MAX SHORT POSITION REACHED");
+             this.soundManager.playError();
         }
     }
 
@@ -76,8 +143,11 @@ export class Terminal {
             if (this.player.payDebt(amount)) {
                 this.log(`PAID $${amount} DEBT`);
                 this.engine.checkWin(this.player.debt);
+                this.soundManager.playBuy();
+                this.particleSystem.spawn(this.width/2, this.height/2, `DEBT -${amount}`, '#00ff00');
             } else {
                 this.log("INSUFFICIENT FUNDS TO PAY DEBT");
+                this.soundManager.playError();
             }
         } else {
              this.log("NO DEBT!");
@@ -122,6 +192,10 @@ export class Terminal {
         this.ctx.fillStyle = this.engine.timeRemaining < 60 ? 'red' : '#00ff00';
         this.ctx.fillText(`TIME: ${Math.ceil(this.engine.timeRemaining)}s`, 600, 30);
 
+        // Draw Level
+        this.ctx.fillStyle = '#00ffff';
+        this.ctx.fillText(`LEVEL: ${this.engine.level}`, 800, 30);
+
 
         // Header
         this.ctx.fillStyle = '#00ff00';
@@ -132,6 +206,9 @@ export class Terminal {
         const listX = 40;
         const listY = 110;
         const lineHeight = 35;
+
+        this.ctx.fillStyle = '#004400';
+        this.ctx.fillText("SYM    SECTOR  PRICE       POS", listX + 20, listY - 25);
 
         this.engine.stocks.forEach((stock, index) => {
             let color = '#00ff00';
@@ -146,10 +223,16 @@ export class Terminal {
             const qty = owned ? owned.quantity : 0;
 
             this.ctx.fillStyle = color;
-            this.ctx.fillText(`${prefix}${stock.symbol.padEnd(6)} $${stock.price.toFixed(2).padStart(8)} [Own: ${qty}]`, listX, listY + index * lineHeight);
+            // Pad columns
+            const sym = stock.symbol.padEnd(6);
+            const sec = stock.sector.padEnd(8);
+            const prc = `$${stock.price.toFixed(2)}`.padStart(9);
+            const pos = qty !== 0 ? `[${qty}]` : `[-]`;
+
+            this.ctx.fillText(`${prefix}${sym} ${sec} ${prc}   ${pos}`, listX, listY + index * lineHeight);
 
             const trendChar = stock.history.length > 1 && stock.history[stock.history.length-1] > stock.history[stock.history.length-2] ? '▲' : '▼';
-            this.ctx.fillText(trendChar, listX + 500, listY + index * lineHeight);
+            this.ctx.fillText(trendChar, listX + 550, listY + index * lineHeight);
         });
 
         // Draw Chart
@@ -159,16 +242,27 @@ export class Terminal {
 
         // Draw Controls Hint
         this.ctx.fillStyle = '#00aa00';
-        this.ctx.fillText("[UP/DOWN] Select  [B] Buy 10  [S] Sell 10  [D] Pay Debt ($1k)  [SPACE] Panic", 40, this.height - 40);
+        this.ctx.fillText("[UP/DOWN] Select  [B] Buy  [S] Sell  [D] Pay Debt  [TAB] Dark Web  [H] Help  [SPACE] Panic", 40, this.height - 80);
 
-        // Draw Messages
+        // Draw Messages (Moved up slightly)
         this.ctx.fillStyle = '#ffff00';
         this.messages.forEach((msg, i) => {
-             this.ctx.fillText(`> ${msg}`, 40, this.height - 80 - i * 30);
+             this.ctx.fillText(`> ${msg}`, 40, this.height - 120 - i * 30);
         });
 
-        // News
-        this.drawNews(40, 450);
+        // News Ticker
+        this.drawTicker(0, this.height - 30);
+
+        // Particles
+        this.particleSystem.draw();
+
+        // Dark Web Overlay
+        this.darkWeb.draw(this.ctx, this.width, this.height);
+
+        // Help Overlay
+        if (this.showHelp) {
+            this.drawHelp();
+        }
     }
 
     drawGameOver() {
@@ -182,17 +276,23 @@ export class Terminal {
         if (this.engine.gameResult === 'WIN') {
             this.ctx.fillStyle = '#00ff00';
             this.ctx.fillText("DEBT PAID! YOU ARE FREE.", this.width/2, this.height/2);
+            this.ctx.font = '30px "VT323", monospace';
+            this.ctx.fillText(`PRESS ENTER FOR LEVEL ${this.engine.level + 1}`, this.width/2, this.height/2 + 50);
         } else {
             this.ctx.fillStyle = 'red';
             this.ctx.fillText("TIME UP. THE SHARKS ARE HERE.", this.width/2, this.height/2);
             this.ctx.font = '30px "VT323", monospace';
             this.ctx.fillText(`DEBT REMAINING: $${this.player.debt.toFixed(2)}`, this.width/2, this.height/2 + 50);
+            this.ctx.fillText("PRESS ENTER TO RESTART", this.width/2, this.height/2 + 100);
         }
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'top';
     }
 
     drawChart(stock: Stock, x: number, y: number, w: number, h: number) {
+        this.ctx.fillStyle = '#002200';
+        this.ctx.fillRect(x, y, w, h);
+
         this.ctx.strokeStyle = '#00ff00';
         this.ctx.lineWidth = 2;
         this.ctx.strokeRect(x, y, w, h);
@@ -203,9 +303,30 @@ export class Terminal {
         const minPrice = Math.min(...stock.history, Math.max(0, stock.price - 10));
         const range = maxPrice - minPrice || 1;
 
+        // Fill path
         this.ctx.beginPath();
         const stepX = w / (stock.history.length - 1);
 
+        this.ctx.moveTo(x, y + h); // Bottom left
+
+        stock.history.forEach((price, i) => {
+            const px = x + i * stepX;
+            const py = y + h - ((price - minPrice) / range) * h;
+            this.ctx.lineTo(px, py);
+        });
+
+        this.ctx.lineTo(x + w, y + h); // Bottom right
+        this.ctx.closePath();
+
+        // Gradient fill
+        const grad = this.ctx.createLinearGradient(x, y, x, y + h);
+        grad.addColorStop(0, "rgba(0, 255, 0, 0.2)");
+        grad.addColorStop(1, "rgba(0, 255, 0, 0)");
+        this.ctx.fillStyle = grad;
+        this.ctx.fill();
+
+        // Stroke line
+        this.ctx.beginPath();
         stock.history.forEach((price, i) => {
             const px = x + i * stepX;
             const py = y + h - ((price - minPrice) / range) * h;
@@ -216,16 +337,83 @@ export class Terminal {
 
          // Label
         this.ctx.fillStyle = '#00ff00';
-        this.ctx.fillText(`${stock.name} (${stock.symbol})`, x, y - 30);
+        this.ctx.fillText(`${stock.name} (${stock.symbol})`, x + 10, y + 20);
     }
 
-    drawNews(x: number, y: number) {
-        this.ctx.fillStyle = '#00aa00';
-        this.ctx.fillText("NEWS FEED:", x, y);
-        this.engine.news.forEach((news, i) => {
-            this.ctx.fillStyle = `rgba(0, 255, 0, ${1 - i * 0.2})`;
-            this.ctx.fillText(`> ${news}`, x, y + 30 + i * 25);
-        });
+    drawTicker(_x: number, y: number) {
+        const fullText = this.engine.news.join("   +++   ") + "   +++   ";
+        const textWidth = this.ctx.measureText(fullText).width;
+
+        // Reset offset if scrolled past
+        if (this.tickerOffset < -textWidth) {
+            this.tickerOffset = this.width;
+        }
+
+        // Start from right side initially if offset is 0?
+        // Actually tickerOffset decrements.
+        if (this.tickerOffset === 0) this.tickerOffset = this.width;
+
+        this.ctx.fillStyle = '#000000';
+        this.ctx.fillRect(0, y, this.width, 30);
+        this.ctx.fillStyle = '#00ff00';
+        this.ctx.fillText(fullText, this.tickerOffset, y + 4);
+
+        // Draw second copy for loop
+        if (this.tickerOffset < 0) {
+             this.ctx.fillText(fullText, this.tickerOffset + textWidth + 100, y + 4);
+        }
+    }
+
+    drawHelp() {
+        this.ctx.fillStyle = "rgba(0, 0, 0, 0.95)";
+        this.ctx.fillRect(50, 50, this.width - 100, this.height - 100);
+        this.ctx.strokeStyle = "#00ff00";
+        this.ctx.lineWidth = 4;
+        this.ctx.strokeRect(50, 50, this.width - 100, this.height - 100);
+
+        this.ctx.fillStyle = "#00ff00";
+        this.ctx.textAlign = "center";
+        this.ctx.font = '40px "VT323", monospace';
+        this.ctx.fillText("NEON BROKER 99 - MANUAL", this.width / 2, 120);
+
+        this.ctx.font = '24px "VT323", monospace';
+        this.ctx.textAlign = "left";
+        const startX = 100;
+        let startY = 180;
+        const line = 35;
+
+        this.ctx.fillText("GOAL: Pay off your DEBT before TIME runs out.", startX, startY);
+        startY += line * 2;
+
+        this.ctx.fillText("CONTROLS:", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [ARROW UP/DOWN] : Select Stock", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [B]             : BUY 10 Shares (or Cover Short)", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [S]             : SELL 10 Shares (or Go Short)", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [D]             : Pay $1000 towards DEBT", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [SPACE]         : PANIC BUTTON (Freeze Market for 5s)", startX, startY);
+        startY += line;
+        this.ctx.fillText("  [TAB]           : Access DARK WEB (Insider Info)", startX, startY);
+        startY += line * 2;
+
+        this.ctx.fillText("TIPS:", startX, startY);
+        startY += line;
+        this.ctx.fillText("- Buy Low, Sell High.", startX, startY);
+        startY += line;
+        this.ctx.fillText("- SHORT SELLING: Sell stock you don't own to profit from drops.", startX, startY);
+        startY += line;
+        this.ctx.fillText("- DARK WEB: Use cash to get insider tips on trends.", startX, startY);
+        startY += line;
+        this.ctx.fillText("- MARGIN: You can spend more than you have, up to a limit.", startX, startY);
+
+        this.ctx.textAlign = "center";
+        this.ctx.fillStyle = "#ffff00";
+        this.ctx.fillText("[PRESS H TO CLOSE]", this.width / 2, this.height - 80);
+        this.ctx.textAlign = "left";
     }
 
     drawScanlines() {

--- a/verification/verify_neon_broker_gameplay.py
+++ b/verification/verify_neon_broker_gameplay.py
@@ -1,0 +1,47 @@
+from playwright.sync_api import sync_playwright
+import time
+
+def verify_neon_broker():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.set_viewport_size({"width": 1280, "height": 720})
+
+        print("Navigating to Neon Broker...")
+        page.goto("http://localhost:3001")
+
+        # Click to resume audio (and start interaction)
+        page.mouse.click(640, 360)
+        time.sleep(1) # Wait for initial render and ticker
+
+        print("Taking initial screenshot...")
+        page.screenshot(path="verification/neon_broker_initial.png")
+
+        # Test Help Overlay
+        print("Testing Help Overlay...")
+        page.keyboard.press("h")
+        time.sleep(0.5)
+        page.screenshot(path="verification/neon_broker_help.png")
+        page.keyboard.press("h") # Close help
+        time.sleep(0.5)
+
+        # Test Dark Web
+        print("Testing Dark Web...")
+        page.keyboard.press("Tab")
+        time.sleep(0.5)
+        page.screenshot(path="verification/neon_broker_darkweb.png")
+        page.keyboard.press("Escape") # Close dark web
+        time.sleep(0.5)
+
+        # Test Buying (Particles)
+        print("Testing Buy Action...")
+        # Select first stock (already selected)
+        page.keyboard.press("b")
+        time.sleep(0.1) # Capture particles
+        page.screenshot(path="verification/neon_broker_buy.png")
+
+        browser.close()
+        print("Verification complete.")
+
+if __name__ == "__main__":
+    verify_neon_broker()


### PR DESCRIPTION
This PR significantly expands "Neon Broker 99" from a basic prototype into a feature-rich arcade game.

**Key Features:**
*   **Audio:** Procedural synthesizer using Web Audio API for sound effects (Buy, Sell, Panic, News) and a dynamic background bassline.
*   **Visuals:** CRT monitor effects (scanlines, flicker, curvature) and particle effects for financial feedback.
*   **Gameplay:**
    *   **Sectors:** Stocks are grouped (TECH, ENERGY, HEAVY), and news can affect entire sectors.
    *   **Short Selling:** Players can sell stocks they don't own to profit from drops.
    *   **Margin/Credit:** Players have a credit line allowing negative cash balances.
    *   **Dark Web:** A new hidden menu (Tab) to buy insider tips or manipulate the market.
    *   **Progression:** A level system with increasing debt quotas and difficulty.
*   **UI/UX:**
    *   Scrolling News Ticker.
    *   Gradient-filled line charts.
    *   In-game Help/Manual (Press H).
    *   Interactive Win/Lose screens.
*   **Deployment:** Added a GitHub Actions workflow to deploy the game to GitHub Pages.

**Verification:**
*   Verified gameplay flow using a custom Playwright script (`verification/verify_neon_broker_gameplay.py`).
*   Confirmed visual fidelity of new UI elements (Dark Web, Help, Ticker).
*   Verified build success via `npm run build`.

---
*PR created automatically by Jules for task [4327294978573815728](https://jules.google.com/task/4327294978573815728) started by @adamvangrover*