### PR TITLE
⚡ Bolt: [performance improvement] Cache CanvasGradient in Runner game

### DIFF
--- a/js/games/runner.js
+++ b/js/games/runner.js
@@ -134,6 +134,14 @@ export default class RunnerGame {
         if (!this.player.isJumping) {
             this.player.y = this.groundY - this.player.height;
         }
+
+        // Bolt Optimization: Cache the background CanvasGradient in the resize() method
+        // to prevent expensive reallocation during the draw() loop on every frame.
+        if (this.ctx) {
+            this.bgGradient = this.ctx.createLinearGradient(0, 0, 0, this.canvas.height);
+            this.bgGradient.addColorStop(0, '#0f172a');
+            this.bgGradient.addColorStop(1, '#1e1b4b');
+        }
     }
 
     resetGame() {
@@ -342,10 +350,8 @@ export default class RunnerGame {
         this.ctx.clearRect(0, 0, width, height);
         
         // Background Gradient
-        const gradient = this.ctx.createLinearGradient(0, 0, 0, height);
-        gradient.addColorStop(0, '#0f172a');
-        gradient.addColorStop(1, '#1e1b4b');
-        this.ctx.fillStyle = gradient;
+        // Bolt Optimization: Use the cached gradient instead of creating a new one every frame
+        this.ctx.fillStyle = this.bgGradient || '#0f172a'; // Fallback in case resize hasn't fired
         this.ctx.fillRect(0, 0, width, height);
         
         // Background Grid (Moving)

--- a/verification/verify_runner_optimization.js
+++ b/verification/verify_runner_optimization.js
@@ -1,0 +1,130 @@
+const fs = require('fs');
+const path = require('path');
+
+// Mocks
+const THREE = {};
+const InputManager = {
+    getInstance: () => ({
+        mouse: { x: 0, y: 0 },
+        isKeyDown: () => false
+    })
+};
+
+const SaveSystem = {
+    getInstance: () => ({
+        getEquippedItem: () => 'blue',
+        getSettings: () => ({}),
+        setSetting: () => {},
+        setEquippedItem: () => {},
+        setHighScore: () => {},
+        addCurrency: () => {}
+    })
+};
+
+const SoundManager = {
+    getInstance: () => ({
+        getAudioData: () => [],
+        playSound: () => {},
+        nextMusicStyle: () => 'acid'
+    })
+};
+
+const ParticleSystem = {
+    getInstance: () => ({
+        emit: () => {},
+        update: () => {},
+        draw: () => {}
+    })
+};
+
+// Global Setup
+global.THREE = THREE;
+global.InputManager = InputManager;
+global.SaveSystem = { getInstance: SaveSystem.getInstance };
+global.SoundManager = { getInstance: SoundManager.getInstance };
+global.ParticleSystem = { getInstance: ParticleSystem.getInstance };
+global.window = {
+    innerWidth: 1024,
+    innerHeight: 768,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    devicePixelRatio: 1,
+    document: {
+        body: { style: {}, appendChild: ()=>{} },
+        createElement: (tag) => ({
+            style: {},
+            classList: { add:()=>{}, remove:()=>{} },
+            appendChild: ()=>{},
+            getContext: () => ({
+                clearRect: () => {},
+                createLinearGradient: () => {
+                    return { addColorStop: () => {} };
+                },
+                fillRect: () => {},
+                beginPath: () => {},
+                moveTo: () => {},
+                lineTo: () => {},
+                stroke: () => {},
+                save: () => {},
+                translate: () => {},
+                rotate: () => {},
+                restore: () => {},
+                fill: () => {},
+                arc: () => {}
+            }),
+            addEventListener: () => {}
+        }),
+        getElementById: () => ({ textContent: '', style: {} }),
+    },
+    navigator: { maxTouchPoints: 0 }
+};
+global.document = global.window.document;
+global.performance = { now: () => Date.now() };
+
+// Read File
+const code = fs.readFileSync(path.join(__dirname, '../js/games/runner.js'), 'utf8');
+
+// Regex to remove imports
+let cleanCode = code.replace(/import .* from .*/g, '');
+
+// Regex to expose class globally
+cleanCode = cleanCode.replace('export default class RunnerGame', 'global.RunnerGame = class RunnerGame');
+
+// Helper to eval
+function runTest() {
+    // Eval the class
+    eval(cleanCode);
+
+    // Instantiate
+    const container = {
+        innerHTML: '',
+        appendChild: () => {},
+        style: {},
+        querySelector: () => ({ addEventListener: () => {} })
+    };
+    const game = new global.RunnerGame();
+    game.init(container);
+
+    let callCount = 0;
+    game.ctx.createLinearGradient = () => {
+        callCount++;
+        return { addColorStop: () => {} };
+    };
+
+    // Simulate Loop
+    console.log("Simulating 60 frames...");
+
+    for(let i=0; i<60; i++) {
+        game.draw();
+    }
+
+    console.log(`createLinearGradient called ${callCount} times in 60 frames.`);
+
+    if (callCount > 10) {
+        console.log("Verdict: NOT Optimized");
+    } else {
+        console.log("Verdict: Optimized (CanvasGradient cached)");
+    }
+}
+
+runTest();


### PR DESCRIPTION
💡 **What**: Moved `CanvasGradient` creation from `draw()` to `resize()` in `js/games/runner.js`. The gradient is now cached in `this.bgGradient` and reused.

🎯 **Why**: Calling `createLinearGradient` and adding color stops on every frame (60+ FPS) is a common performance anti-pattern in Canvas applications. It causes unnecessary object allocation and forces frequent garbage collection. Since the gradient dimensions only change when the window is resized, it can be safely cached.

📊 **Impact**: Eliminates 1 `CanvasGradient` allocation per frame (~3600 per minute), reducing GC pauses and potentially smoothing out framerates on lower-end devices.

🔬 **Measurement**: Verified using a headless Node.js mock that tracks calls to `createLinearGradient`. Before the change, it was called 60 times over 60 frames. After the change, it is called 0 times during the draw loop (only once during init/resize). Run `node verification/verify_runner_optimization.js` to see the test pass.

---
*PR created automatically by Jules for task [4437054698380642335](https://jules.google.com/task/4437054698380642335) started by @adamvangrover*