### PR TITLE
docs: enforce Async Agent CRAFT+S prompt usage in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,9 @@ This document provides instructions for autonomous agents working on the Neon Ar
 
 *   **Run Existing Tests**: Before submitting, run relevant existing verification scripts (e.g., `verification/verify_full.py`) to ensure no regressions were introduced.
 *   **Dependency Management**: Be careful when adding new global dependencies. Prefer using existing libraries (Three.js, localized physics, etc.) available in the repo.
+
+## 5. Async Agent Persona (CRAFT+S)
+
+*   **Mandatory Prompt**: All async agents *must* use the **CRAFT+S Prompt Module** located at `docs/prompts/CRAFT_S.md`.
+*   **Adherence**: Adhere strictly to the persona, context, and workflow constraints defined within that prompt.
+*   **Self-Contained Modules**: The prompt strictly enforces self-contained, modular development. Follow it rigorously.

--- a/verification/verify_prompt_alignment.py
+++ b/verification/verify_prompt_alignment.py
@@ -27,7 +27,9 @@ def main():
             "Self-Contained Modules",
             "Verification",
             "Log",
-            "SaveSystem"
+            "SaveSystem",
+            "CRAFT_S.md",
+            "Async Agent Persona"
         ]),
         ('README.md', [
             "Vanilla JavaScript",


### PR DESCRIPTION
This PR addresses the user's request to enforce the use of the CRAFT+S prompt for async agents.

Changes:
- Added Section 5 "Async Agent Persona (CRAFT+S)" to `AGENTS.md` to explicitly mandate that all async agents must use the **CRAFT+S Prompt Module** located at `docs/prompts/CRAFT_S.md`.
- Updated `verification/verify_prompt_alignment.py` to add `"CRAFT_S.md"` and `"Async Agent Persona"` to the required strings list for `AGENTS.md` to strictly enforce the prompt mandate.

The file `docs/prompts/CRAFT_S.md` with the required prompt was already present in the codebase.

---
*PR created automatically by Jules for task [4667918687876117205](https://jules.google.com/task/4667918687876117205) started by @adamvangrover*