### PR TITLE
⚡ Bolt: Replace distanceTo with distanceToSquared in neonShooter.js for performance

### DIFF
--- a/js/games/neonShooter.js
+++ b/js/games/neonShooter.js
@@ -213,7 +213,8 @@ export default class NeonShooter {
             e.mesh.lookAt(this.camera.position);
 
             // Player Collision (Damage)
-            if (e.mesh.position.distanceTo(this.camera.position) < 1.5) {
+            // Bolt Optimization: Replace distanceTo with distanceToSquared to bypass expensive Math.sqrt in high-frequency game loop
+            if (e.mesh.position.distanceToSquared(this.camera.position) < 2.25) {
                 this.player.health -= 10 * dt;
 
                 if (this.healthEl) {
@@ -245,7 +246,8 @@ export default class NeonShooter {
             // Bullet Collision
             for (let j = this.enemies.length - 1; j >= 0; j--) {
                 let e = this.enemies[j];
-                if (b.mesh.position.distanceTo(e.mesh.position) < 1.0) {
+                // Bolt Optimization: Replace distanceTo with distanceToSquared to bypass expensive Math.sqrt in high-frequency game loop
+                if (b.mesh.position.distanceToSquared(e.mesh.position) < 1.0) {
                     // Hit
                     e.health--;
                     this.scene.remove(b.mesh);


### PR DESCRIPTION
💡 What: Replacing `distanceTo` with `distanceToSquared` in collision checks in `neonShooter.js`.
🎯 Why: Avoids expensive `Math.sqrt` calls during every frame in high-frequency loops (bullets vs enemies).
📊 Impact: Improves frame rate and reduces CPU usage during intense combat scenes.
🔬 Measurement: Observe frame rate using `python3 verification/verify_neon_shooter_perf.py`.

---
*PR created automatically by Jules for task [3377339588105995361](https://jules.google.com/task/3377339588105995361) started by @adamvangrover*